### PR TITLE
Added citet command

### DIFF
--- a/_global_settings.tex
+++ b/_global_settings.tex
@@ -39,6 +39,11 @@
 \DeclareFieldFormat*{title}{``#1''\newunitpunct} % move comma outside the quotation mark
 \addbibresource{references.bib}
 
+\newcommand{\citet}[1]{%
+	\AtNextCite{\defcounter{maxnames}{1}\defcounter{minnames}{1}}%
+	\citeauthor{#1}%
+}
+
 \usepackage{microtype} % Better typography
 \usepackage{tabulary} % Automatic table sizing
 \usepackage{hhline}

--- a/chapters/ch-intro.tex
+++ b/chapters/ch-intro.tex
@@ -23,7 +23,7 @@ A book~\cite{BOOK:Gray} is cited.
   \label{intro:fig:vege}
 \end{figure}
 
-An online article~\cite{tpc-c} is cited.
+An online article~\cite{tpc-c} is cited. \citet{tods92:Mohan} created a new area.
 
 \autoref{intro:fig:vege} demonstrates a collection of vegetables. 
 There are broccoli, carrot, pea, onion, snow bean, scallion, etc.


### PR DESCRIPTION
The `citet` command from the `natbib` package is useful for citing the first author name but omitting the others with "et al." appended. However, introducing the `natbib` package seems conflicting with the template. Alternatively, we provide this command seperately.

Close Issue #18 